### PR TITLE
docs: Add documentation on dummy flavors

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,21 @@ Dummy is a konnector used for development, debugging and test purpose. It is use
 Install
 -------
 
-Since `dummy` is only for development purpose, it must not be available in the Cozy store and as such is only published
-on the `dev` channel.
+Since `dummy` is only for development purposes, it must not be available in the Cozy store and as such is only published
+on GitHub and on the registry in the dev channel. Travis automatically updates thoses branches and the registry when a
+change lands on master.
+
+### Flavors
+
+- `build`: Dummy connector
+- `build_aggregator`: Used to test the aggregator account feature used in Banking konnectors
+- `build_form`
+- `build_oauth`
+- `build_twofa`: Used to test 2FA flow for example for the [Amazon](https://github.com/konnectors/amazon) connector
+
+Each of this flavor is published on a build branch, for example [here](https://github.com/konnectors/dummy/tree/build_twofa)
+
+Additionally, the 2FA flavor is published in the registry at `registry://dummy/dev`.
 
 ```bash
 cozy-stack konnectors install dummy registry://dummy/dev

--- a/README.md
+++ b/README.md
@@ -24,13 +24,14 @@ change lands on master.
 
 - `build`: Dummy connector
 - `build_aggregator`: Used to test the aggregator account feature used in Banking konnectors
-- `build_form`
+- `build_form`: Used to test various form elements used in the authentication form
 - `build_oauth`
 - `build_twofa`: Used to test 2FA flow for example for the [Amazon](https://github.com/konnectors/amazon) connector
 
-Each of this flavor is published on a build branch, for example [here](https://github.com/konnectors/dummy/tree/build_twofa)
+Each of this flavor is published on a build branch, for example [here](https://github.com/konnectors/dummy/tree/build_twofa).
 
-Additionally, the 2FA flavor is published in the registry at `registry://dummy/dev`.
+Additionally, the 2FA flavor is published in the registry at `registry://dummy/dev`. It can be useful for flows
+where it is not suitable to install the connector via the CLI.
 
 ```bash
 cozy-stack konnectors install dummy registry://dummy/dev

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Install
 -------
 
 Since `dummy` is only for development purposes, it must not be available in the Cozy store and as such is only published
-on GitHub and on the registry in the dev channel. Travis automatically updates thoses branches and the registry when a
+on GitHub and on the registry in the dev channel. Travis automatically updates those branches and the registry when a
 change lands on master.
 
 ### Flavors
@@ -25,7 +25,7 @@ change lands on master.
 - `build`: Dummy connector
 - `build_aggregator`: Used to test the aggregator account feature used in Banking konnectors
 - `build_form`: Used to test various form elements used in the authentication form
-- `build_oauth`
+- `build_oauth`: Used to test oauth flow. Real example : [Facebook](https://github.com/konnectors/cozy-konnector-facebook/)
 - `build_twofa`: Used to test 2FA flow for example for the [Amazon](https://github.com/konnectors/amazon) connector
 
 Each of this flavor is published on a build branch, for example [here](https://github.com/konnectors/dummy/tree/build_twofa).


### PR DESCRIPTION
What are flavors for the dummy konnector and where are they published. 