### PR TITLE
Better twoFA konnector

### DIFF
--- a/flavours/twofa/index.js
+++ b/flavours/twofa/index.js
@@ -1,0 +1,32 @@
+const { BaseKonnector } = require('cozy-konnector-libs')
+
+const TWOFA_EXPIRATION_TIMEOUT = 30000
+
+async function start(fields) {
+  const startTime = Date.now()
+
+  const {
+    twoFACode,
+    twoFATimeout = TWOFA_EXPIRATION_TIMEOUT,
+    tries = '1'
+  } = fields
+
+  const endTime = startTime + twoFATimeout
+
+  let code = await this.waitForTwoFaCode({
+    timeout: endTime,
+    retry: false
+  })
+
+  if (code !== twoFACode && tries === '2') {
+    await this.waitForTwoFaCode({ timeout: endTime, retry: true })
+  }
+
+  if (code === twoFACode) {
+    await this.updateAccountAttributes({ state: 'LOGIN_SUCCESS' })
+  } else {
+    throw new Error('USER_ACTION_NEEDED.WRONG_TWOFA_CODE')
+  }
+}
+
+module.exports = new BaseKonnector(start)

--- a/flavours/twofa/manifest.fragment.json
+++ b/flavours/twofa/manifest.fragment.json
@@ -8,35 +8,49 @@
     "password": {
       "type": "password"
     },
-    "two_fa_code": {
+    "twoFACode": {
       "default": "Cozy2FA"
     },
-    "error": {
+    "twoFATimeout": {
+      "default": "30000"
+    },
+    "tries": {
       "type": "dropdown",
-      "isRequired": false,
-      "required": false,
+      "default": "1",
       "options": [
-        {
-          "label": "-",
-          "name": "-",
-          "value": ""
-        },
-        {
-          "label": "USER_ACTION_NEEDED.WRONG_TWOFA_CODE",
-          "name": "USER_ACTION_NEEDED.WRONG_TWOFA_CODE",
-          "value": "USER_ACTION_NEEDED.WRONG_TWOFA_CODE"
-        },
-        {
-          "label": "USER_ACTION_NEEDED.WRONG_TWOFA_CODE_2_ATTEMPTS",
-          "name": "USER_ACTION_NEEDED.WRONG_TWOFA_CODE_2_ATTEMPTS",
-          "value": "USER_ACTION_NEEDED.WRONG_TWOFA_CODE_2_ATTEMPTS"
-        },
-        {
-          "label": "USER_ACTION_NEEDED.TWOFA_EXPIRED",
-          "name": "USER_ACTION_NEEDED.TWOFA_EXPIRED",
-          "value": "USER_ACTION_NEEDED.TWOFA_EXPIRED"
-        }
+        { "label": "1", "value": "1" },
+        { "label": "2", "value": "2" }
       ]
+    }
+  },
+  "locales": {
+    "en": {
+      "description": "Konnector used for debug purpose",
+      "fields": {
+        "twoFACode": {
+          "label": "Expected 2FA code"
+        },
+        "twoFATimeout": {
+          "label": "2FA Code expiration delay"
+        },
+        "tries": {
+          "label": "Allowed tries"
+        }
+      }
+    },
+    "fr": {
+      "description": "Konnecteur de débogage",
+      "fields": {
+        "twoFACode": {
+          "label": "Code 2FA attendu"
+        },
+        "twoFATimeout": {
+          "label": "Délai d'expiration du code 2FA"
+        },
+        "tries": {
+          "label": "Nombre d'essais"
+        }
+      }
     }
   }
 }

--- a/flavours/twofa/manifest.fragment.json
+++ b/flavours/twofa/manifest.fragment.json
@@ -1,6 +1,6 @@
 {
   "name": "Dummy 2FA",
-  "slug": "dummy",
+  "slug": "dummy-twofa",
   "fields": {
     "login": {
       "type": "text"

--- a/scripts/postbuild.sh
+++ b/scripts/postbuild.sh
@@ -11,4 +11,9 @@ find flavours/* -prune -type d -exec basename {} \; | while IFS= read -r d; do
     jq -s '.[0] + .[1]' "build-$d/manifest.konnector" "flavours/$d/manifest.fragment.json" > "build-$d/manifest.temp"
     rm "build-$d/manifest.konnector"
     mv "build-$d/manifest.temp" "build-$d/manifest.konnector"
+    # index.js
+    if [[ -e "flavours/$d/index.js" ]]
+    then
+      yarn webpack "flavours/$d/index.js" -o "build-$d/index.js" --config webpack.flavour.config.js
+    fi
 done

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-const { BaseKonnector, log } = require('cozy-konnector-libs')
+const { BaseKonnector } = require('cozy-konnector-libs')
 const sleep = require('util').promisify(global.setTimeout)
 
 const konnectorErrors = [
@@ -19,8 +19,6 @@ const konnectorErrors = [
   'VENDOR_DOWN.LINXO_DOWN'
 ]
 
-const startTime = Date.now()
-
 async function start(fields) {
   const timeout = Number(fields.timeout) || 1000
   if (timeout > 0) {
@@ -30,63 +28,8 @@ async function start(fields) {
       konnectorErrors.includes(fields.error.toUpperCase())
     ) {
       throw new Error(fields.error.toUpperCase())
-    } else if (fields.two_fa_code) {
-      await handle2FA.bind(this)(fields)
-      return
-    } else {
-      return
     }
   }
-}
-
-async function handle2FA(fields) {
-  log('info', `handle2FA account state : ${this._account.state}`)
-  log('info', `handle2FA account revision : ${this._account._rev}`)
-  const setState = _setState.bind(this)
-  const twoFACodeAttempts = _twoFACodeAttempts.bind(this)
-  await setState('HANDLE_LOGIN_SUCCESS')
-  log(
-    'info',
-    `handle2FA before attempts account state : ${this._account.state}`
-  )
-  if (fields.error) {
-    if (fields.error === 'USER_ACTION_NEEDED.WRONG_TWOFA_CODE') {
-      await twoFACodeAttempts(fields, 1, 5)
-    }
-
-    if (fields.error === 'USER_ACTION_NEEDED.TWOFA_EXPIRED') {
-      await twoFACodeAttempts(fields, 1, 0)
-      await sleep(1000)
-    }
-
-    if (fields.error === 'USER_ACTION_NEEDED.WRONG_TWOFA_CODE_2_ATTEMPTS') {
-      await twoFACodeAttempts(fields, 2, 3)
-    }
-    throw new Error(fields.error)
-  } else {
-    await twoFACodeAttempts(fields, 1, 3)
-  }
-  log('info', `handle2FA after attempts account state : ${this._account.state}`)
-  await setState('LOGIN_SUCCESS')
-  log(
-    'info',
-    `handle2FA after LOGIN_SUCCESS account state : ${this._account.state}`
-  )
-}
-
-async function _twoFACodeAttempts(fields, nbAttempts = 3, maxDurationMin = 3) {
-  const timeout = startTime + maxDurationMin * 60 * 1000
-  let retry = false
-  for (let i = 1; i <= nbAttempts; i++) {
-    if (i > 1) retry = true
-    const code = await this.waitForTwoFaCode({ timeout, retry })
-    log('info', `Got the ${code} code`)
-    await sleep(1000)
-  }
-}
-
-async function _setState(state) {
-  return this.updateAccountAttributes({ state })
 }
 
 module.exports = new BaseKonnector(start)

--- a/webpack.flavour.config.js
+++ b/webpack.flavour.config.js
@@ -1,0 +1,10 @@
+const entry = require('./package.json').main
+
+module.exports = {
+  entry,
+  target: 'node',
+  mode: 'none',
+  output: {
+    filename: 'index.js'
+  }
+}


### PR DESCRIPTION
The TwoFA Dummy konnector was previously part of the main Dummy konnector. Logic was based on a test over the `two_fa_code` field.

It was not acting like a real Two FA konnector, and was based, like the basic Dummy Konnector, on a `error` field. That was not really useful during tests.

This PR :
- Allow definition of specific index.js in `flavours` directory
- Adds an index.js file in the `flavours/twofa` which deals only with 2FA logic. This logic now mimics a real 2FA konnector
- Removes all logic related to 2FA in the main index.js file