### PR TITLE
fix: Change category to categories in bank flavour manifest

### DIFF
--- a/flavours/bank/manifest.fragment.json
+++ b/flavours/bank/manifest.fragment.json
@@ -1,7 +1,7 @@
 {
   "name": "Bank (Dummy)",
   "slug": "dummy-bank",
-  "category": "banking",
+  "categories": ["banking"],
   "data_types": ["bankAccounts"],
   "fields": {
     "login": {


### PR DESCRIPTION
This old category option in bank manifest is there since a long time.

Now the way to set it is an array of strings.


@ptbrowne I let you merge that if it seems legit to you.